### PR TITLE
Fixed Disable Cache Setting

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,7 @@ class $modify(MyLevelCell, LevelCell) {
 			return;
 		}
 		auto txtr = CCTextureCache::get()->textureForKey(fmt::format("thumb-{}",(int)this->m_level->m_levelID).c_str());
-		if (txtr && Mod::get()->getSettingValue<bool>("disableCache")) {
+		if (txtr && !Mod::get()->getSettingValue<bool>("disableCache")) {
 			this->onDownloadFinished(CCSprite::createWithTexture(txtr));
 			return;
 		}


### PR DESCRIPTION
Added a `!` because before the setting was opposite of what the cache actually did.

Ex. Turning on `Disable Cache` would actually enable the cache and vice versa.