### PR TITLE
v1.0.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # v1.0.4
+- Fixed an issue where levels in lists would show the wrong thumbnail
+
+# v1.0.4
 - Fixed some lag issues
-- Fixed the download button on the thumbnail popup taking you to a 404 page.
+- Fixed the download button on the thumbnail popup taking you to a 404 page
 
 # v1.0.3
 - Switched from GitHub Pages to rawgithubusercontent

--- a/mod.json
+++ b/mod.json
@@ -1,7 +1,7 @@
 {
 	"geode": "2.0.0-beta.23",
 	"gd": { "win": "2.204", "android": "2.205" },
-	"version": "v1.0.4",
+	"version": "v1.0.5",
 	"id": "cdc.level_thumbnails",
 	"name": "Level Thumbnails",
 	"developer": "cdc",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@ class $modify(MyLevelCell, LevelCell) {
 
 	void loadCustomLevelCell() {
 		LevelCell::loadCustomLevelCell();
+
 		this->m_fields->background = getChildOfType<CCLayerColor>(this, 0);
 		this->m_fields->background->setZOrder(-2);
 		this->m_fields->separatorSprite = CCSprite::create(Mod::get()->getSettingValue<bool>("alternativeSpacer") ? "streakb_01_001.png" : "square02_001.png");
@@ -26,6 +27,12 @@ class $modify(MyLevelCell, LevelCell) {
 		auto mainLayer = this->getChildByID("main-layer");
 		auto mainMenu = mainLayer->getChildByID("main-menu");
 		auto viewButton = mainMenu->getChildByID("view-button");
+
+		// Check if the level has been loaded (lists sometimes show the cell before the level is loaded)
+		CCMenuItemSpriteExtra* name = static_cast<CCMenuItemSpriteExtra*>(mainMenu->getChildByID("creator-name"));
+		CCLabelBMFont* nameText = static_cast<CCLabelBMFont*>(name->getChildren()->objectAtIndex(0));
+		std::string nameStr = nameText->getString();
+		if (nameStr.length() == 0) return;
 
 		this->m_fields->loadingIndicator = LoadingCircle::create();
 		this->m_fields->loadingIndicator->setParentLayer(this);


### PR DESCRIPTION
Fixed an issue where levels in lists would show the wrong thumbnail. To prevent this, it checks to see if the username is empty. If it is, it returns out of the function. It will run once again when the level is loaded, so this is all it needs to do.