### PR TITLE
Rules update

### DIFF
--- a/resources/submission_rules.md
+++ b/resources/submission_rules.md
@@ -1,23 +1,29 @@
-1. Overlays of any kind are not allowed (progress bar, Globed, Mega Hack, etc.).
+1. Before submitting, if the thumbnail preview looks AT ALL different from the level, do not submit it. The screenshot tool isn't perfect and bugs do get through.
 
-2. Custom icon texture packs are allowed, but your icon must still look like an icon (no faces or heavily altered designs). Level object-altering texture packs are not allowed.
+2. Overlays of any kind are not allowed. While many are already automatically disabled by the mod, not all of them are. Anything that's added onto the screen by a mod is an overlay.
 
-3. Practice checkpoints cannot be visible in the thumbnail (in-level checkpoints such as platformer checkpoints are allowed).
+3. Custom icon texture packs are allowed, but your icon must still look like an icon (no faces or heavily altered designs), or in other words: adjacent to vanilla. Texture packs that modify the look of level objects, backgrounds, or particles are not allowed.
 
-4. Please show the gameplay of the level, title cards and transitions are not allowed.
+4. Most trails added or modified by mods are not allowed, with the exception of anything that only modifies the regular player trail shown in other gamemodes as long as it is adjacent to vanilla. Disabling the wave trail is also not allowed.
 
-5. Particles (such as around orbs and portals) and shaders should be enabled, and LDM should be off in Main Menu > Settings > Help.
+5. Please show the gameplay of the level, title cards and transitions are not allowed.
 
-6. Do not use a level's built-in LDM.
+6. Particles (such as around orbs and portals) and shaders should be enabled, and LDM should be off in Main Menu > Settings > Help.
 
-7. Hitboxes, death effects, and spawn effects are not allowed.
+7. Do not use a level's built-in LDM.
 
-8. You cannot be close to death in your thumbnail.
+8. Hitboxes, death effects, and spawn effects are not allowed.
 
-9. Avoid submitting the first couple percentages of the level if possible, please use an actually good part in the level, show the best/most fun looking part.
+9. You cannot be close to death or have noclipped through an object in your thumbnail.
 
-10. Use high graphics settings (Main Menu > Settings > Graphics, if you're on mobile use the High Graphics on Mobile mod).
+10. You cannot be visibly speedhacking/using an autoclicker unless you're playing a section of a level where it's required.
 
-11. If your thumbnail is glitched in any way during the preview (like due to a bug in the mod), do NOT submit it.
+11. Avoid submitting the first couple percentages of the level if possible, please use an actually good part in the level, show the best/most fun looking part.
 
-12. Avoid submitting thumbnails for random recent tab levels, there are a LOT of thumbnails for the mods to go through and little Timmy levels do not need thumbnails.
+12. Use high graphics settings (Main Menu > Settings > Graphics > Texture Quality: High). If you're on mobile, use the High Graphics on Mobile mod (note that using high graphics on mobile may have visual bugs, if these are present in your thumbnail then it will be rejected).
+
+13. Avoid submitting thumbnails for random recent tab levels, there are a LOT of thumbnails for the mods to go through and little Timmy levels do not need thumbnails.
+
+14. Do not submit thumbnails for NSFW levels.
+
+15. Do not put slurs in your submission notes.


### PR DESCRIPTION
- Added clarification to the overlays rule, custom icons rule, and close to death rule
- Added 4 new rules about trails (rule 4), speedhacking (rule 10), NSFW (rule 14), and slurs in submission notes (rule 15)
- Added warning about visual bugs from using high graphics on mobile
- Moved the "don't submit if thumbnail glitched" rule to the top
- Removed the practice checkpoint rule as practice checkpoints get automatically hidden now